### PR TITLE
Add IHttpClientFactory support and fix HttpClient lifetime

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Two NuGet libraries for Azure DevOps REST API access:
 - **LoDaTek.AzureDevOps.Services.Client** — standalone, lightweight client for REST APIs *missing* from the official SDK (feeds, NuGet packages, secure files, some agile/work-item bits). Depends only on `Microsoft.TeamFoundation*` task/server packages + `System.Text.Json`. This is the lower layer.
 - **LoDaTek.AzureDevOps.Client** — wrapper over the *official* `Microsoft.VisualStudio.Services.*` SDK clients (Git, TFVC, WorkItem, Wiki, Build, Release, Pipelines, etc.) plus a project reference to Services.Client. `AzureDevOpsProvider` exposes all official clients lazily and adds builders/extensions (`WiqlBuilder`, work-item extensions). This is the higher layer.
 
-`SampleWPF` (net9.0-windows) and `TestApp` (net9.0 console) are example consumers, not shipped.
+`SampleWPF` (net10.0-windows) and `TestApp` (net10.0 console) are example consumers, not shipped.
 
 ## Build / Run
 
@@ -22,9 +22,9 @@ dotnet run --project TestApp        # console smoke test
 dotnet test LoDaTek.AzureDevOps.Tests/LoDaTek.AzureDevOps.Tests.csproj   # unit tests
 ```
 
-Both libraries multi-target `netstandard2.0;net9.0;net10.0`. The `netstandard2.0` target gets extra `System.Net.Http.Json` / `System.Text.Json` package references (see conditional `ItemGroup` in Services.Client csproj) — preserve that when touching JSON code so netstandard keeps compiling.
+Both libraries multi-target `netstandard2.0;net10.0`. The `netstandard2.0` target gets extra `System.Net.Http.Json` / `System.Text.Json` package references (see conditional `ItemGroup` in Services.Client csproj) — preserve that when touching JSON code so netstandard keeps compiling.
 
-`LoDaTek.AzureDevOps.Tests` (MSTest, net9.0) holds the tests. It overrides the signing/packaging defaults from `Directory.Build.props`.
+`LoDaTek.AzureDevOps.Tests` (MSTest, net10.0) holds the tests. It overrides the signing/packaging defaults from `Directory.Build.props`.
 
 - **Unit tests** (always run): pure-logic coverage (connection URLs, `WiqlBuilder`, DI registration) plus offline HTTP tests that inject a stub `IHttpClientFactory` to exercise `TryConnect`/auth without a live server.
 - **Integration tests** (`Integration/`, `[TestCategory("Integration")]`): hit a live Azure DevOps org, gated on env vars — required `AZDO_ORG` + `AZDO_PAT`, optional `AZDO_PROJECT` / `AZDO_FEED`. When unset they `Assert.Inconclusive` (skip, not fail). `IntegrationConfig` reads the vars and builds connections/providers. All read-only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,15 @@ dotnet test LoDaTek.AzureDevOps.Tests/LoDaTek.AzureDevOps.Tests.csproj   # unit 
 
 Both libraries multi-target `netstandard2.0;net9.0;net10.0`. The `netstandard2.0` target gets extra `System.Net.Http.Json` / `System.Text.Json` package references (see conditional `ItemGroup` in Services.Client csproj) — preserve that when touching JSON code so netstandard keeps compiling.
 
-`LoDaTek.AzureDevOps.Tests` (MSTest, net9.0) holds the unit tests — pure-logic coverage (connection URLs, `WiqlBuilder`, DI registration) plus offline HTTP tests that inject a stub `IHttpClientFactory` to exercise `TryConnect`/auth without a live server. It overrides the signing/packaging defaults from `Directory.Build.props`. Live API calls remain manual via `TestApp`.
+`LoDaTek.AzureDevOps.Tests` (MSTest, net9.0) holds the tests. It overrides the signing/packaging defaults from `Directory.Build.props`.
+
+- **Unit tests** (always run): pure-logic coverage (connection URLs, `WiqlBuilder`, DI registration) plus offline HTTP tests that inject a stub `IHttpClientFactory` to exercise `TryConnect`/auth without a live server.
+- **Integration tests** (`Integration/`, `[TestCategory("Integration")]`): hit a live Azure DevOps org, gated on env vars — required `AZDO_ORG` + `AZDO_PAT`, optional `AZDO_PROJECT` / `AZDO_FEED`. When unset they `Assert.Inconclusive` (skip, not fail). `IntegrationConfig` reads the vars and builds connections/providers. All read-only.
+
+```
+dotnet test --filter TestCategory!=Integration   # unit only
+dotnet test --filter TestCategory=Integration     # integration only (needs env vars)
+```
 
 ## Architecture (Services.Client)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,46 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Two NuGet libraries for Azure DevOps REST API access:
+
+- **LoDaTek.AzureDevOps.Services.Client** — standalone, lightweight client for REST APIs *missing* from the official SDK (feeds, NuGet packages, secure files, some agile/work-item bits). Depends only on `Microsoft.TeamFoundation*` task/server packages + `System.Text.Json`. This is the lower layer.
+- **LoDaTek.AzureDevOps.Client** — wrapper over the *official* `Microsoft.VisualStudio.Services.*` SDK clients (Git, TFVC, WorkItem, Wiki, Build, Release, Pipelines, etc.) plus a project reference to Services.Client. `AzureDevOpsProvider` exposes all official clients lazily and adds builders/extensions (`WiqlBuilder`, work-item extensions). This is the higher layer.
+
+`SampleWPF` (net9.0-windows) and `TestApp` (net9.0 console) are example consumers, not shipped.
+
+## Build / Run
+
+No `.sln` file. Build per-project or the whole folder:
+
+```
+dotnet build LoDaTek.AzureDevOps.Services.Client/LoDaTek.AzureDevOps.Services.Client.csproj
+dotnet build LoDaTek.AzureDevOps.Client/LoDaTek.AzureDevOps.Client.csproj
+dotnet run --project TestApp        # console smoke test
+```
+
+Both libraries multi-target `netstandard2.0;net9.0;net10.0`. The `netstandard2.0` target gets extra `System.Net.Http.Json` / `System.Text.Json` package references (see conditional `ItemGroup` in Services.Client csproj) — preserve that when touching JSON code so netstandard keeps compiling.
+
+No test project exists.
+
+## Architecture (Services.Client)
+
+Read these together to understand the connection model:
+
+- `Bases/DevOpsConnectionBase.cs` — abstract base holding org name + PAT. Subclasses (`Connections/AzureDevOpsCloudConnection`, `AzureDevOpsLegacyCloudConnection`, `AzureDevOpsServerConnection`) only differ by the URL properties they expose (`CommonUrl`, `FeedsApiUrl`, `NugetPackagesApiUrl`, `BaseUrl`) and `ServerType`. To support a new host shape, add a connection subclass — don't branch on URLs elsewhere.
+- `GetClient<T>()` / `GetClientAsync<T>()` use **reflection** to construct `DevOpsHttpClientBase` subclasses via their **internal constructor**, then call `TryConnect`. This is why HTTP client ctors are `internal` and take a `DevOpsConnectionBase` — keep that ctor signature or reflection breaks.
+- `Bases/DevOpsHttpClientBase.cs` — each client declares an `ApiType` (`Feeds`/`Nuget`/`Common`, see `Enums/ApiType.cs`) which selects the base URL from the connection. Auth is PAT as HTTP Basic: base64 of `":" + PAT`. `TryConnect` GETs the client's `TestUrl` and treats only 404 as failure. A fresh `HttpClient` is built per request via the `Client` property.
+
+Concrete clients: `FeedManagmentHttpClient`, `PackageManagementHttpClient`, `SecureFilesHttpClient`. DTOs live in `Models/`, custom exceptions in `Exceptions/` (`ConnectionFailureException`, `PATPermissionDeniedException`, `RequestFailureException`).
+
+## Architecture (Client wrapper)
+
+`AzureDevOpsProvider` (`LoDaTek.AzureDevOps.Client/AzureDevOpsProvider.cs`) is constructed from a `DevOpsConnectionBase` and lazily creates each official SDK client off a shared `VssConnection` (built from `connection.CommonUrl` + `VssBasicCredential`). The Services.Client clients (feed/package/secure-files) are also surfaced here, so consumers use one provider for both official and missing APIs. This file uses `Newtonsoft.Json` (official SDK contract) — distinct from Services.Client which uses `System.Text.Json`.
+
+## Conventions
+
+- XML doc comments on all public/internal members (often GhostDoc-style boilerplate) — match the existing density.
+- British spelling in identifiers (`OrganisationName`, `DevOpsOrganisation`).
+- Regions (`#region Fields/Properties/Constructors/Methods`) structure every class.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,11 +19,12 @@ No `.sln` file. Build per-project or the whole folder:
 dotnet build LoDaTek.AzureDevOps.Services.Client/LoDaTek.AzureDevOps.Services.Client.csproj
 dotnet build LoDaTek.AzureDevOps.Client/LoDaTek.AzureDevOps.Client.csproj
 dotnet run --project TestApp        # console smoke test
+dotnet test LoDaTek.AzureDevOps.Tests/LoDaTek.AzureDevOps.Tests.csproj   # unit tests
 ```
 
 Both libraries multi-target `netstandard2.0;net9.0;net10.0`. The `netstandard2.0` target gets extra `System.Net.Http.Json` / `System.Text.Json` package references (see conditional `ItemGroup` in Services.Client csproj) — preserve that when touching JSON code so netstandard keeps compiling.
 
-No test project exists.
+`LoDaTek.AzureDevOps.Tests` (MSTest, net9.0) holds the unit tests — pure-logic coverage (connection URLs, `WiqlBuilder`, DI registration) plus offline HTTP tests that inject a stub `IHttpClientFactory` to exercise `TryConnect`/auth without a live server. It overrides the signing/packaging defaults from `Directory.Build.props`. Live API calls remain manual via `TestApp`.
 
 ## Architecture (Services.Client)
 

--- a/LoDaTek.AzureDevOps.Client/AzureDevOpsProvider.cs
+++ b/LoDaTek.AzureDevOps.Client/AzureDevOpsProvider.cs
@@ -40,13 +40,10 @@ public class AzureDevOpsProvider
     private ReleaseHttpClient _releaseClient;
     private SecurityHttpClient _securityClient;
     private ExtensionManagementHttpClient _extensionClient;
-    private GalleryHttpClient _galleryClient;
     private TaskAgentHttpClient _taskAgentHttpClient;
     private PipelinesHttpClient _pipelinesHttpClient;
     private TeamHttpClient _teamClient;
     private HttpClient _galleryNetClient;
-
-    IDevOpsConnection _restApiConnection;
 
     #endregion
 
@@ -373,7 +370,7 @@ public class AzureDevOpsProvider
                 return project;
             }
         }
-        catch (ProjectDoesNotExistWithNameException e)
+        catch (ProjectDoesNotExistWithNameException)
         {
             // if project not found then just return null
             return null;
@@ -610,7 +607,12 @@ public class AzureDevOpsProvider
     {
         try
         {
+            // GetFieldsAsync is obsolete; the replacement GetWorkItemFieldsAsync returns the newer
+            // WorkItemField2 model, which would change this method's public return type. Suppress here
+            // to keep the existing public signature.
+#pragma warning disable CS0612
             var fields = await WorkItemClient.GetFieldsAsync(projectRemoteId);
+#pragma warning restore CS0612
 
             return fields;
         }
@@ -1231,7 +1233,7 @@ public class AzureDevOpsProvider
 
                     break;
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     if (tries > maxTries)
                         throw;

--- a/LoDaTek.AzureDevOps.Client/AzureDevOpsProvider.cs
+++ b/LoDaTek.AzureDevOps.Client/AzureDevOpsProvider.cs
@@ -43,6 +43,7 @@ public class AzureDevOpsProvider
     private GalleryHttpClient _galleryClient;
     private TaskAgentHttpClient _taskAgentHttpClient;
     private PipelinesHttpClient _pipelinesHttpClient;
+    private TeamHttpClient _teamClient;
 
     IDevOpsConnection _restApiConnection;
 
@@ -288,6 +289,20 @@ public class AzureDevOpsProvider
         }
     }
 
+    /// <summary>
+    /// Gets the pipelines client.
+    /// </summary>
+    /// <value>The pipelines client.</value>
+    public TeamHttpClient TeamClient
+    {
+        get
+        {
+            if (_teamClient == null)
+                _teamClient = Connection.GetClient<TeamHttpClient>();
+
+            return _teamClient;
+        }
+    }
     #endregion
 
     #region Constructors

--- a/LoDaTek.AzureDevOps.Client/AzureDevOpsProvider.cs
+++ b/LoDaTek.AzureDevOps.Client/AzureDevOpsProvider.cs
@@ -44,6 +44,7 @@ public class AzureDevOpsProvider
     private TaskAgentHttpClient _taskAgentHttpClient;
     private PipelinesHttpClient _pipelinesHttpClient;
     private TeamHttpClient _teamClient;
+    private HttpClient _galleryNetClient;
 
     IDevOpsConnection _restApiConnection;
 
@@ -235,12 +236,15 @@ public class AzureDevOpsProvider
     {
         get
         {
-            var client = new HttpClient();
-            client.DefaultRequestHeaders.Accept.Clear();
-            client.DefaultRequestHeaders.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+            if (_galleryNetClient == null)
+            {
+                _galleryNetClient = new HttpClient();
+                _galleryNetClient.DefaultRequestHeaders.Accept.Clear();
+                _galleryNetClient.DefaultRequestHeaders.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
+                _galleryNetClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+            }
 
-            return client;
+            return _galleryNetClient;
         }
     }
 

--- a/LoDaTek.AzureDevOps.Client/LoDaTek.AzureDevOps.Client.csproj
+++ b/LoDaTek.AzureDevOps.Client/LoDaTek.AzureDevOps.Client.csproj
@@ -15,6 +15,10 @@
 		<PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="20.256.2" />
 		<PackageReference Include="Microsoft.VisualStudio.Services.Release.Client" Version="20.256.2" />
 		<PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
+		<!-- Pin patched versions to override vulnerable transitive packages pulled by the VisualStudio.Services SDK -->
+		<PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+		<PackageReference Include="System.Formats.Asn1" Version="9.0.17" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.17" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/LoDaTek.AzureDevOps.Client/LoDaTek.AzureDevOps.Client.csproj
+++ b/LoDaTek.AzureDevOps.Client/LoDaTek.AzureDevOps.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net9.0;net10.0;</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net10.0;</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Summary>Wrapper for Azure DevOps Client libraries</Summary>
 		<Description>Wrapper for Azure DevOps Client libraries to make it easier to access both supported and unsupported Rest APIs</Description>

--- a/LoDaTek.AzureDevOps.Services.Client/Bases/DevOpsConnectionBase.cs
+++ b/LoDaTek.AzureDevOps.Services.Client/Bases/DevOpsConnectionBase.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Net.Http;
 using LoDaTek.AzureDevOps.Services.Client.Connections;
 using LoDaTek.AzureDevOps.Services.Client.Enums;
 using LoDaTek.AzureDevOps.Services.Client.Exceptions;
@@ -19,9 +20,32 @@ public abstract class DevOpsConnectionBase : IDisposable, IDevOpsConnection
     #region Fields
     private string _personalAccessToken;
     private string _organisationName;
+    private IHttpClientFactory _httpClientFactory;
+    #endregion
+
+    #region Constants
+
+    /// <summary>
+    /// Name of the <see cref="HttpClient"/> registered via
+    /// <c>AddAzureDevOpsHttpClient</c> and resolved from <see cref="HttpClientFactory"/>.
+    /// </summary>
+    public const string HttpClientName = "LoDaTek.AzureDevOps";
+
     #endregion
 
     #region Properties
+
+    /// <summary>
+    /// Gets or sets the optional HTTP client factory.
+    /// When set, REST clients resolve their <see cref="HttpClient"/> from the factory
+    /// (using <see cref="HttpClientName"/>) instead of a self-managed instance.
+    /// </summary>
+    /// <value>The HTTP client factory, or <c>null</c> to use the built-in client.</value>
+    public IHttpClientFactory HttpClientFactory
+    {
+        get { return _httpClientFactory; }
+        set { _httpClientFactory = value; }
+    }
 
     /// <summary>
     /// Gets the name of the organisation.

--- a/LoDaTek.AzureDevOps.Services.Client/Bases/DevOpsHttpClientBase.cs
+++ b/LoDaTek.AzureDevOps.Services.Client/Bases/DevOpsHttpClientBase.cs
@@ -17,6 +17,7 @@ public abstract class DevOpsHttpClientBase
 
     private DevOpsConnectionBase _connection;
     private ApiType _apiType;
+    private HttpClient _client;
 
     #endregion
 
@@ -44,15 +45,7 @@ public abstract class DevOpsHttpClientBase
     /// Gets the client.
     /// </summary>
     /// <value>The client.</value>
-    protected HttpClient Client
-    {
-        get
-        {
-            var client = BuildAuthenticationClient(ApiUrl);
-
-            return client;
-        }
-    }
+    protected HttpClient Client => _client ??= BuildAuthenticationClient(ApiUrl);
 
     /// <summary>
     /// Gets the API URL.
@@ -98,29 +91,7 @@ public abstract class DevOpsHttpClientBase
     /// Tries the connect.
     /// </summary>
     /// <returns><c>true</c> if XXXX, <c>false</c> otherwise.</returns>
-    internal bool TryConnect()
-    {
-        try
-        {
-            var client = BuildAuthenticationClient();
-            client.Timeout = TimeSpan.FromSeconds(3000);
-
-            var task = Task.Run(() => client.GetAsync(TestUrl));
-            task.Wait();
-            var response = task.Result;
-
-            if (response.StatusCode == HttpStatusCode.NotFound)
-            {
-                return false;
-            }
-
-            return true;
-        }
-        catch
-        {
-            return false;
-        }
-    }
+    internal bool TryConnect() => TryConnectAsync().GetAwaiter().GetResult();
 
     /// <summary>
     /// Try connect as an asynchronous operation.
@@ -130,18 +101,17 @@ public abstract class DevOpsHttpClientBase
     {
         try
         {
-            var client = BuildAuthenticationClient();
-            client.Timeout = TimeSpan.FromSeconds(3000);
+            var response = await Client.GetAsync(TestUrl);
 
-            var result = await client.GetAsync(TestUrl);
-
-            if (result.StatusCode == HttpStatusCode.NotFound)
+            switch (response.StatusCode)
             {
-                return false;
+                case HttpStatusCode.NotFound:
+                case HttpStatusCode.Unauthorized:
+                case HttpStatusCode.Forbidden:
+                    return false;
+                default:
+                    return true;
             }
-
-            return true;
-
         }
         catch
         {
@@ -159,6 +129,7 @@ public abstract class DevOpsHttpClientBase
         handler.AllowAutoRedirect = false;
 
         var client = new HttpClient(handler);
+        client.Timeout = TimeSpan.FromSeconds(30);
         client.DefaultRequestHeaders.Accept.Clear();
         client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
@@ -186,7 +157,8 @@ public abstract class DevOpsHttpClientBase
     /// <exception cref="NotImplementedException"></exception>
     public void Dispose()
     {
-
+        _client?.Dispose();
+        _client = null;
     }
 
     #endregion

--- a/LoDaTek.AzureDevOps.Services.Client/Bases/DevOpsHttpClientBase.cs
+++ b/LoDaTek.AzureDevOps.Services.Client/Bases/DevOpsHttpClientBase.cs
@@ -45,7 +45,20 @@ public abstract class DevOpsHttpClientBase
     /// Gets the client.
     /// </summary>
     /// <value>The client.</value>
-    protected HttpClient Client => _client ??= BuildAuthenticationClient(ApiUrl);
+    protected HttpClient Client
+    {
+        get
+        {
+            var factory = _connection.HttpClientFactory;
+
+            // Factory clients are pooled and short-lived: resolve a fresh one each
+            // time and never cache or dispose it (the factory owns the handler).
+            if (factory != null)
+                return ConfigureClient(factory.CreateClient(DevOpsConnectionBase.HttpClientName));
+
+            return _client ??= BuildAuthenticationClient(ApiUrl);
+        }
+    }
 
     /// <summary>
     /// Gets the API URL.
@@ -120,16 +133,16 @@ public abstract class DevOpsHttpClientBase
     }
 
     /// <summary>
-    /// Builds an authenticated HTTP client.
+    /// Applies the base address (when unset), accept and authorization headers.
+    /// Used for both self-built and factory-provided clients.
     /// </summary>
+    /// <param name="client">The client to configure.</param>
     /// <returns>HttpClient.</returns>
-    private HttpClient BuildAuthenticationClient()
+    private HttpClient ConfigureClient(HttpClient client)
     {
-        var handler = new HttpClientHandler();
-        handler.AllowAutoRedirect = false;
+        if (client.BaseAddress == null)
+            client.BaseAddress = new Uri(ApiUrl);
 
-        var client = new HttpClient(handler);
-        client.Timeout = TimeSpan.FromSeconds(30);
         client.DefaultRequestHeaders.Accept.Clear();
         client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
@@ -138,17 +151,18 @@ public abstract class DevOpsHttpClientBase
     }
 
     /// <summary>
-    /// Builds the authentication client.
+    /// Builds a self-managed authenticated HTTP client (used when no factory is set).
     /// </summary>
-    /// <param name="url">The URL.</param>
+    /// <param name="url">The base URL.</param>
     /// <returns>HttpClient.</returns>
     private HttpClient BuildAuthenticationClient(string url)
     {
-        var client = BuildAuthenticationClient();
+        var handler = new HttpClientHandler { AllowAutoRedirect = false };
 
+        var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(30) };
         client.BaseAddress = new Uri(url);
 
-        return client;
+        return ConfigureClient(client);
     }
 
     /// <summary>

--- a/LoDaTek.AzureDevOps.Services.Client/Extensions/ServiceCollectionExtensions.cs
+++ b/LoDaTek.AzureDevOps.Services.Client/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Net.Http;
+using LoDaTek.AzureDevOps.Services.Client.Bases;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LoDaTek.AzureDevOps.Services.Client.Extensions;
+
+/// <summary>
+/// Dependency injection helpers for the Azure DevOps REST clients.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the named <see cref="HttpClient"/> (<see cref="DevOpsConnectionBase.HttpClientName"/>)
+    /// used by the REST clients, configured to match the built-in client
+    /// (redirects disabled, 30 second timeout).
+    /// Assign the resolved <c>IHttpClientFactory</c> to
+    /// <see cref="DevOpsConnectionBase.HttpClientFactory"/> on each connection to use it.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection, for chaining.</returns>
+    public static IServiceCollection AddAzureDevOpsHttpClient(this IServiceCollection services)
+    {
+        services.AddHttpClient(DevOpsConnectionBase.HttpClientName)
+            .ConfigureHttpClient(client => client.Timeout = TimeSpan.FromSeconds(30))
+            .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler { AllowAutoRedirect = false });
+
+        return services;
+    }
+}

--- a/LoDaTek.AzureDevOps.Services.Client/FeedManagmentHttpClient.cs
+++ b/LoDaTek.AzureDevOps.Services.Client/FeedManagmentHttpClient.cs
@@ -45,19 +45,18 @@ public sealed class FeedManagmentHttpClient : DevOpsHttpClientBase
     /// <exception cref="LoDaTek.AzureDevOps.Services.Client.Exceptions.RequestFailureException">Unable to find feeds</exception>
     public async Task<List<Feed>> GetFeedsAsync()
     {
-        using (var client = Client)
+        var client = Client;
+
+        var response = await client.GetAsync("packaging/feeds?api-version=5.0-preview.1");
+
+        //check to see if we have a successful response
+        if (response.IsSuccessStatusCode)
         {
-            var response = await client.GetAsync("packaging/feeds?api-version=5.0-preview.1");
+            //set the viewmodel from the content in the response
+            var result = await response.Content.ReadFromJsonAsync<FeedResponse>();
 
-            //check to see if we have a successful response
-            if (response.IsSuccessStatusCode)
-            {
-                //set the viewmodel from the content in the response
-                var result = await response.Content.ReadFromJsonAsync<FeedResponse>();
-
-                if (result != null)
-                    return result.Feeds;
-            }
+            if (result != null)
+                return result.Feeds;
         }
 
         throw new RequestFailureException("Unable to find feeds");
@@ -78,21 +77,18 @@ public sealed class FeedManagmentHttpClient : DevOpsHttpClientBase
     /// <exception cref="LoDaTek.AzureDevOps.Services.Client.Exceptions.RequestFailureException">Unable to fetch packages</exception>
     public async Task<List<Package>> GetPackagesAsync(Guid feedId)
     {
-        using (var client = Client)
+        var client = Client;
+
+        var response = await client.GetAsync($"packaging/feeds/{feedId}/packages?includeAllVersions=true&api-version=5.0-preview.1");
+
+        //check to see if we have a successful response
+        if (response.IsSuccessStatusCode)
         {
-            var response = await client.GetAsync($"packaging/feeds/{feedId}/packages?includeAllVersions=true&api-version=5.0-preview.1");
+            //set the viewmodel from the content in the response
+            var result = await response.Content.ReadFromJsonAsync<PackagesResponse>();
 
-            //check to see if we have a successful response
-            if (response.IsSuccessStatusCode)
-            {
-                var json = await response.Content.ReadAsStringAsync();
-
-                //set the viewmodel from the content in the response
-                var result = await response.Content.ReadFromJsonAsync<PackagesResponse>();
-
-                if (result != null)
-                    return result.Packages;
-            }
+            if (result != null)
+                return result.Packages;
         }
 
         throw new RequestFailureException("Unable to fetch packages");

--- a/LoDaTek.AzureDevOps.Services.Client/LoDaTek.AzureDevOps.Services.Client.csproj
+++ b/LoDaTek.AzureDevOps.Services.Client/LoDaTek.AzureDevOps.Services.Client.csproj
@@ -14,6 +14,10 @@
 		<PackageReference Include="Microsoft.TeamFoundation.DistributedTask.WebApi" Version="20.256.2" />
 		<PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="20.256.2" />
 		<PackageReference Include="System.Configuration.ConfigurationManager" Version="[8.0.0]" />
+		<!-- Pin patched versions to override vulnerable transitive packages pulled by the TeamFoundation SDK -->
+		<PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+		<PackageReference Include="System.Formats.Asn1" Version="9.0.17" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.17" />
 	</ItemGroup>
 	
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">

--- a/LoDaTek.AzureDevOps.Services.Client/LoDaTek.AzureDevOps.Services.Client.csproj
+++ b/LoDaTek.AzureDevOps.Services.Client/LoDaTek.AzureDevOps.Services.Client.csproj
@@ -16,8 +16,8 @@
 	</ItemGroup>
 	
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
-		<PackageReference Include="System.Net.Http.Json" Version="10.0.8" />
-		<PackageReference Include="System.Text.Json" Version="10.0.8" />
+		<PackageReference Include="System.Net.Http.Json" Version="10.0.9" />
+		<PackageReference Include="System.Text.Json" Version="10.0.9" />
 	</ItemGroup>
 	
 </Project>

--- a/LoDaTek.AzureDevOps.Services.Client/LoDaTek.AzureDevOps.Services.Client.csproj
+++ b/LoDaTek.AzureDevOps.Services.Client/LoDaTek.AzureDevOps.Services.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net9.0;net10.0;</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net10.0;</TargetFrameworks>
 		<Summary>Client access library for the Azure DevOps Rest API</Summary>
 		<Description>Client access library for the Azure DevOps Rest API, for the bits missing from the official library such as feeds and packages</Description>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/LoDaTek.AzureDevOps.Services.Client/LoDaTek.AzureDevOps.Services.Client.csproj
+++ b/LoDaTek.AzureDevOps.Services.Client/LoDaTek.AzureDevOps.Services.Client.csproj
@@ -10,6 +10,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
 		<PackageReference Include="Microsoft.TeamFoundation.DistributedTask.WebApi" Version="20.256.2" />
 		<PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="20.256.2" />
 		<PackageReference Include="System.Configuration.ConfigurationManager" Version="[8.0.0]" />

--- a/LoDaTek.AzureDevOps.Services.Client/PackageManagementHttpClient.cs
+++ b/LoDaTek.AzureDevOps.Services.Client/PackageManagementHttpClient.cs
@@ -45,39 +45,29 @@ public class PackageManagementHttpClient : DevOpsHttpClientBase
     /// <returns>A Task&lt;System.String&gt; representing the asynchronous operation.</returns>
     public async Task<string> GetNugetBasePathAsync(string feedName, string projectName = null)
     {
-        using (var wclient = Client)
+        var wclient = Client;
+
+        var url = GetNuGetUrl(feedName, projectName);
+
+        var response = await wclient.GetAsync(url);
+
+        if (response.IsSuccessStatusCode)
         {
-            var url = GetNuGetUrl(feedName, projectName);
+            //set the viewmodel from the content in the response
+            var queryResult = await response.Content.ReadFromJsonAsync<ServiceDetails>();
 
-            var response = await wclient.GetAsync(url);
+            if (queryResult == null)
+                return null;
 
-            //var queryResult = JsonConvert.DeserializeObject<ServiceDetails>(result);
+            var queryResource = queryResult["SearchQueryService/3.0.0-beta"];
+            var packageBaseResource = queryResult["PackageBaseAddress/3.0.0"];
 
-            if (response.IsSuccessStatusCode)
+            if (queryResource == null || packageBaseResource == null)
             {
-
-                var json = await response.Content.ReadAsStringAsync();
-
-                //set the viewmodel from the content in the response
-                var queryResult = await response.Content.ReadFromJsonAsync<ServiceDetails>();
-
-                if (queryResult == null)
-                    return null;
-
-                var queryResource = queryResult["SearchQueryService/3.0.0-beta"];
-                var packageBaseResource = queryResult["PackageBaseAddress/3.0.0"];
-                var feedDetails = queryResult["VssFeedId"];
-
-                if (queryResource == null || packageBaseResource == null)
-                {
-                    return null;
-                }
-
-                var queryUrl = queryResource.Id;
-                var packageBaseUrl = packageBaseResource.Id;
-
-                return packageBaseUrl;
+                return null;
             }
+
+            return packageBaseResource.Id;
         }
 
         return null;
@@ -97,40 +87,36 @@ public class PackageManagementHttpClient : DevOpsHttpClientBase
         var tries = 0;
         var maxTries = 10;
 
-        using (var wclient = Client)
+        var wclient = Client;
+
+        var packageUrl = $"{baseUrl}/{packageName}/{packageVersion}/{packageName}.{packageVersion}.nupkg";
+
+        while (true)
         {
-            var packageUrl = $"{baseUrl}/{packageName}/{packageVersion}/{packageName}.{packageVersion}.nupkg";
-
-            while (true)
+            try
             {
-                try
-                {
-                    var response = await wclient.GetAsync(new Uri(packageUrl, UriKind.Absolute));
+                var response = await wclient.GetAsync(new Uri(packageUrl, UriKind.Absolute));
 
-                    response.EnsureSuccessStatusCode();
+                response.EnsureSuccessStatusCode();
 
-                    var data = await response.Content.ReadAsByteArrayAsync();
+                var data = await response.Content.ReadAsByteArrayAsync();
 #if NETSTANDARD2_0
-                    File.WriteAllBytes(outPutFileName, data);
+                File.WriteAllBytes(outPutFileName, data);
 #else
-                    await File.WriteAllBytesAsync(outPutFileName, data);
+                await File.WriteAllBytesAsync(outPutFileName, data);
 #endif
-                    return;
-                }
-                catch
-                {
-                    if (tries > maxTries)
-                        throw;
-
-                    await Task.Delay(5000);
-
-                    tries++;
-                }
+                return;
             }
+            catch
+            {
+                if (tries > maxTries)
+                    throw;
 
+                await Task.Delay(5000);
+
+                tries++;
+            }
         }
-
-        throw new RequestFailureException("Unable to fetch packages");
     }
 
 

--- a/LoDaTek.AzureDevOps.Services.Client/SecureFilesHttpClient.cs
+++ b/LoDaTek.AzureDevOps.Services.Client/SecureFilesHttpClient.cs
@@ -41,22 +41,21 @@ public sealed class SecureFilesHttpClient : DevOpsHttpClientBase
     /// <exception cref="RequestFailureException">Unable to find feeds</exception>
     public async Task<List<SecureFile>> GetAllAsync(TeamProjectReference project)
     {
-        using (var client = Client)
+        var client = Client;
+
+        var requestUrl = BuildApiUrl(project);
+
+        var response = await client.GetAsync(requestUrl);
+
+        //check to see if we have a successful response
+        if (response.IsSuccessStatusCode)
         {
-            var requestUrl = BuildApiUrl(project);
+            //set the viewmodel from the content in the response
+            var result = await response.Content.ReadAsAsync<VssJsonCollectionWrapper<List<SecureFile>>>(new MediaTypeFormatter[1] { new VssJsonMediaTypeFormatter() });
 
-            var response = await client.GetAsync(requestUrl);
-
-            //check to see if we have a successful response
-            if (response.IsSuccessStatusCode)
+            if (result != null)
             {
-                //set the viewmodel from the content in the response
-                var result = await response.Content.ReadAsAsync<VssJsonCollectionWrapper<List<SecureFile>>>(new MediaTypeFormatter[1] { new VssJsonMediaTypeFormatter() });
-
-                if (result != null)
-                {
-                    return result.Value;
-                }
+                return result.Value;
             }
         }
 

--- a/LoDaTek.AzureDevOps.Tests/ConnectionUrlTests.cs
+++ b/LoDaTek.AzureDevOps.Tests/ConnectionUrlTests.cs
@@ -1,0 +1,56 @@
+using LoDaTek.AzureDevOps.Services.Client.Connections;
+using LoDaTek.AzureDevOps.Services.Client.Enums;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LoDaTek.AzureDevOps.Tests;
+
+/// <summary>
+/// Verifies each connection subclass builds the correct URLs for its host shape.
+/// </summary>
+[TestClass]
+public class ConnectionUrlTests
+{
+    private const string Org = "contoso";
+    private const string Pat = "token";
+
+    [TestMethod]
+    public void CloudConnection_BuildsExpectedUrls()
+    {
+        var connection = new AzureDevOpsCloudConnection(Org, Pat);
+
+        Assert.AreEqual(ServerType.AzureDevOps, connection.ServerType);
+        Assert.AreEqual("https://dev.azure.com/contoso/", connection.CommonUrl);
+        Assert.AreEqual("https://feeds.dev.azure.com/contoso/_apis/", connection.FeedsApiUrl);
+        Assert.AreEqual("https://pkgs.dev.azure.com/contoso/", connection.NugetPackagesApiUrl);
+    }
+
+    [TestMethod]
+    public void LegacyCloudConnection_BuildsExpectedUrls()
+    {
+        var connection = new AzureDevOpsLegacyCloudConnection(Org, Pat);
+
+        Assert.AreEqual(ServerType.AzureDevOps, connection.ServerType);
+        Assert.AreEqual("https://contoso.visualstudio.com/", connection.CommonUrl);
+        Assert.AreEqual("https://contoso.feeds.visualstudio.com/_apis/", connection.FeedsApiUrl);
+        Assert.AreEqual("https://contoso.pkgs.visualstudio.com/", connection.NugetPackagesApiUrl);
+    }
+
+    [TestMethod]
+    public void ServerConnection_BuildsExpectedUrls()
+    {
+        var connection = new AzureDevOpsServerConnection("https://devops.local", "DefaultCollection", Pat);
+
+        Assert.AreEqual(ServerType.DevOpsServer, connection.ServerType);
+        Assert.AreEqual("https://devops.local/DefaultCollection/", connection.CommonUrl);
+        Assert.AreEqual("https://devops.local/DefaultCollection//_apis/", connection.FeedsApiUrl);
+    }
+
+    [TestMethod]
+    public void Connection_RetainsOrganisationAndToken()
+    {
+        var connection = new AzureDevOpsCloudConnection(Org, Pat);
+
+        Assert.AreEqual(Org, connection.OrganisationName);
+        Assert.AreEqual(Pat, connection.PersonalAccessToken);
+    }
+}

--- a/LoDaTek.AzureDevOps.Tests/Helpers/StubHttpMessageHandler.cs
+++ b/LoDaTek.AzureDevOps.Tests/Helpers/StubHttpMessageHandler.cs
@@ -1,0 +1,61 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LoDaTek.AzureDevOps.Tests.Helpers;
+
+/// <summary>
+/// Test message handler that returns a canned status code and records the last request,
+/// so tests can exercise HTTP behaviour without a live server.
+/// </summary>
+public sealed class StubHttpMessageHandler : HttpMessageHandler
+{
+    private readonly HttpStatusCode _statusCode;
+
+    /// <summary>
+    /// Gets the most recent request seen by the handler.
+    /// </summary>
+    public HttpRequestMessage LastRequest { get; private set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StubHttpMessageHandler"/> class.
+    /// </summary>
+    /// <param name="statusCode">The status code to return for every request.</param>
+    public StubHttpMessageHandler(HttpStatusCode statusCode)
+    {
+        _statusCode = statusCode;
+    }
+
+    /// <inheritdoc />
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        LastRequest = request;
+
+        return Task.FromResult(new HttpResponseMessage(_statusCode)
+        {
+            Content = new StringContent("{}"),
+            RequestMessage = request,
+        });
+    }
+}
+
+/// <summary>
+/// Minimal <see cref="IHttpClientFactory"/> that hands out clients backed by a supplied handler.
+/// </summary>
+public sealed class StubHttpClientFactory : IHttpClientFactory
+{
+    private readonly HttpMessageHandler _handler;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StubHttpClientFactory"/> class.
+    /// </summary>
+    /// <param name="handler">The handler that backs every created client.</param>
+    public StubHttpClientFactory(HttpMessageHandler handler)
+    {
+        _handler = handler;
+    }
+
+    /// <inheritdoc />
+    public HttpClient CreateClient(string name) => new HttpClient(_handler);
+}

--- a/LoDaTek.AzureDevOps.Tests/HttpClientResolutionTests.cs
+++ b/LoDaTek.AzureDevOps.Tests/HttpClientResolutionTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using LoDaTek.AzureDevOps.Services.Client;
+using LoDaTek.AzureDevOps.Services.Client.Connections;
+using LoDaTek.AzureDevOps.Services.Client.Exceptions;
+using LoDaTek.AzureDevOps.Tests.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LoDaTek.AzureDevOps.Tests;
+
+/// <summary>
+/// Exercises connection / client behaviour offline by injecting a stub
+/// <see cref="System.Net.Http.IHttpClientFactory"/> via the new factory support.
+/// </summary>
+[TestClass]
+public class HttpClientResolutionTests
+{
+    private const string Org = "contoso";
+    private const string Pat = "secret-pat";
+
+    [TestMethod]
+    public async Task GetClientAsync_SuccessStatus_ReturnsConnectedClient()
+    {
+        var handler = new StubHttpMessageHandler(HttpStatusCode.OK);
+        var connection = new AzureDevOpsCloudConnection(Org, Pat)
+        {
+            HttpClientFactory = new StubHttpClientFactory(handler),
+        };
+
+        var client = await connection.GetClientAsync<SecureFilesHttpClient>();
+
+        Assert.IsNotNull(client);
+        Assert.IsNotNull(handler.LastRequest, "TryConnect should have issued a request.");
+    }
+
+    [TestMethod]
+    public async Task GetClientAsync_NotFound_ThrowsConnectionFailure()
+    {
+        var handler = new StubHttpMessageHandler(HttpStatusCode.NotFound);
+        var connection = new AzureDevOpsCloudConnection(Org, Pat)
+        {
+            HttpClientFactory = new StubHttpClientFactory(handler),
+        };
+
+        await Assert.ThrowsExceptionAsync<ConnectionFailureException>(
+            () => connection.GetClientAsync<SecureFilesHttpClient>());
+    }
+
+    [TestMethod]
+    public async Task GetClientAsync_AppliesBasicAuthHeaderFromPat()
+    {
+        var handler = new StubHttpMessageHandler(HttpStatusCode.OK);
+        var connection = new AzureDevOpsCloudConnection(Org, Pat)
+        {
+            HttpClientFactory = new StubHttpClientFactory(handler),
+        };
+
+        await connection.GetClientAsync<SecureFilesHttpClient>();
+
+        var auth = handler.LastRequest.Headers.Authorization;
+        var expected = Convert.ToBase64String(Encoding.ASCII.GetBytes(":" + Pat));
+
+        Assert.AreEqual("Basic", auth.Scheme);
+        Assert.AreEqual(expected, auth.Parameter);
+    }
+}

--- a/LoDaTek.AzureDevOps.Tests/Integration/FeedAndPackageIntegrationTests.cs
+++ b/LoDaTek.AzureDevOps.Tests/Integration/FeedAndPackageIntegrationTests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using LoDaTek.AzureDevOps.Services.Client;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LoDaTek.AzureDevOps.Tests.Integration;
+
+/// <summary>
+/// Read-only integration tests for the feed and package REST clients.
+/// Gated on AZDO_ORG / AZDO_PAT; skipped (inconclusive) when not configured.
+/// </summary>
+[TestClass]
+[TestCategory("Integration")]
+public class FeedAndPackageIntegrationTests
+{
+    [TestMethod]
+    public async Task GetFeedsAsync_ReturnsFeedList()
+    {
+        var connection = IntegrationConfig.RequireConnection();
+
+        var client = await connection.GetClientAsync<FeedManagmentHttpClient>();
+        var feeds = await client.GetFeedsAsync();
+
+        Assert.IsNotNull(feeds, "Expected a (possibly empty) feed list, not null.");
+    }
+
+    [TestMethod]
+    public async Task GetPackagesAsync_ForFirstFeed_ReturnsPackageList()
+    {
+        var connection = IntegrationConfig.RequireConnection();
+
+        var client = await connection.GetClientAsync<FeedManagmentHttpClient>();
+        var feeds = await client.GetFeedsAsync();
+
+        if (feeds == null || feeds.Count == 0)
+            Assert.Inconclusive("No feeds available in the organisation to query packages for.");
+
+        var packages = await client.GetPackagesAsync(feeds[0].Id);
+
+        Assert.IsNotNull(packages, "Expected a (possibly empty) package list, not null.");
+    }
+
+    [TestMethod]
+    public async Task GetNugetBasePathAsync_ForNamedFeed_ReturnsBaseUrl()
+    {
+        var connection = IntegrationConfig.RequireConnection();
+        var feedName = IntegrationConfig.RequireValue(IntegrationConfig.Feed, "AZDO_FEED");
+
+        var client = await connection.GetClientAsync<PackageManagementHttpClient>();
+        var baseUrl = await client.GetNugetBasePathAsync(feedName, IntegrationConfig.Project);
+
+        Assert.IsFalse(string.IsNullOrWhiteSpace(baseUrl), "Expected a non-empty NuGet base path.");
+        StringAssert.StartsWith(baseUrl, "http");
+    }
+}

--- a/LoDaTek.AzureDevOps.Tests/Integration/IntegrationConfig.cs
+++ b/LoDaTek.AzureDevOps.Tests/Integration/IntegrationConfig.cs
@@ -1,0 +1,69 @@
+using System;
+using LoDaTek.AzureDevOps.Client;
+using LoDaTek.AzureDevOps.Services.Client.Connections;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LoDaTek.AzureDevOps.Tests.Integration;
+
+/// <summary>
+/// Reads Azure DevOps connection details from environment variables and builds
+/// connections / providers for the integration tests. When the required variables
+/// are absent the helpers raise <see cref="Assert.Inconclusive(string)"/> so the
+/// tests are skipped rather than failed on machines without credentials.
+/// </summary>
+/// <remarks>
+/// Required: <c>AZDO_ORG</c>, <c>AZDO_PAT</c>.
+/// Optional: <c>AZDO_PROJECT</c> (project name or id), <c>AZDO_FEED</c> (feed name or id).
+/// </remarks>
+internal static class IntegrationConfig
+{
+    /// <summary>Gets the organisation name (<c>AZDO_ORG</c>).</summary>
+    public static string Organisation => Environment.GetEnvironmentVariable("AZDO_ORG");
+
+    /// <summary>Gets the personal access token (<c>AZDO_PAT</c>).</summary>
+    public static string PersonalAccessToken => Environment.GetEnvironmentVariable("AZDO_PAT");
+
+    /// <summary>Gets the optional project name or id (<c>AZDO_PROJECT</c>).</summary>
+    public static string Project => Environment.GetEnvironmentVariable("AZDO_PROJECT");
+
+    /// <summary>Gets the optional feed name or id (<c>AZDO_FEED</c>).</summary>
+    public static string Feed => Environment.GetEnvironmentVariable("AZDO_FEED");
+
+    /// <summary>
+    /// Gets a value indicating whether the required credentials are present.
+    /// </summary>
+    public static bool IsConfigured =>
+        !string.IsNullOrWhiteSpace(Organisation) && !string.IsNullOrWhiteSpace(PersonalAccessToken);
+
+    /// <summary>
+    /// Builds a cloud connection, or skips the test when credentials are missing.
+    /// </summary>
+    /// <returns>A configured <see cref="AzureDevOpsCloudConnection"/>.</returns>
+    public static AzureDevOpsCloudConnection RequireConnection()
+    {
+        if (!IsConfigured)
+            Assert.Inconclusive("Integration tests skipped: set AZDO_ORG and AZDO_PAT to run them.");
+
+        return new AzureDevOpsCloudConnection(Organisation, PersonalAccessToken);
+    }
+
+    /// <summary>
+    /// Builds a provider over a cloud connection, or skips the test when credentials are missing.
+    /// </summary>
+    /// <returns>A configured <see cref="AzureDevOpsProvider"/>.</returns>
+    public static AzureDevOpsProvider RequireProvider() => new AzureDevOpsProvider(RequireConnection());
+
+    /// <summary>
+    /// Skips the current test when the named variable is absent.
+    /// </summary>
+    /// <param name="value">The variable value.</param>
+    /// <param name="name">The variable name, for the skip message.</param>
+    /// <returns>The value when present.</returns>
+    public static string RequireValue(string value, string name)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            Assert.Inconclusive($"Test skipped: set {name} to run it.");
+
+        return value;
+    }
+}

--- a/LoDaTek.AzureDevOps.Tests/Integration/ProviderIntegrationTests.cs
+++ b/LoDaTek.AzureDevOps.Tests/Integration/ProviderIntegrationTests.cs
@@ -1,0 +1,65 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LoDaTek.AzureDevOps.Tests.Integration;
+
+/// <summary>
+/// Read-only integration tests for <see cref="LoDaTek.AzureDevOps.Client.AzureDevOpsProvider"/>.
+/// Gated on AZDO_ORG / AZDO_PAT; skipped (inconclusive) when not configured.
+/// </summary>
+[TestClass]
+[TestCategory("Integration")]
+public class ProviderIntegrationTests
+{
+    [TestMethod]
+    public async Task GetProjectsAsync_ReturnsProjects()
+    {
+        var provider = IntegrationConfig.RequireProvider();
+
+        var projects = await provider.GetProjectsAsync();
+
+        Assert.IsNotNull(projects, "Expected a (possibly empty) project list, not null.");
+    }
+
+    [TestMethod]
+    public async Task GetProjectAsync_ForNamedProject_ReturnsProject()
+    {
+        var provider = IntegrationConfig.RequireProvider();
+        var projectName = IntegrationConfig.RequireValue(IntegrationConfig.Project, "AZDO_PROJECT");
+
+        var project = await provider.GetProjectAsync(projectName);
+
+        Assert.IsNotNull(project, $"Project '{projectName}' was not found.");
+        Assert.AreEqual(projectName, project.Name);
+    }
+
+    [TestMethod]
+    public async Task FetchAvailableFeedsAsync_ReturnsFeeds()
+    {
+        var provider = IntegrationConfig.RequireProvider();
+
+        var feeds = await provider.FetchAvailableFeedsAsync();
+
+        Assert.IsNotNull(feeds, "Expected a (possibly empty) feed list, not null.");
+    }
+
+    [TestMethod]
+    public async Task SecureFiles_ForFirstProject_ReturnsList()
+    {
+        var provider = IntegrationConfig.RequireProvider();
+
+        var projects = await provider.GetProjectsAsync();
+
+        if (projects == null || projects.Count == 0)
+            Assert.Inconclusive("No projects available to query secure files for.");
+
+        var project = string.IsNullOrWhiteSpace(IntegrationConfig.Project)
+            ? projects.First()
+            : projects.First(p => p.Name == IntegrationConfig.Project);
+
+        var secureFiles = await provider.SecureFilesClient.GetAllAsync(project);
+
+        Assert.IsNotNull(secureFiles, "Expected a (possibly empty) secure file list, not null.");
+    }
+}

--- a/LoDaTek.AzureDevOps.Tests/LoDaTek.AzureDevOps.Tests.csproj
+++ b/LoDaTek.AzureDevOps.Tests/LoDaTek.AzureDevOps.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net9.0</TargetFramework>
+		<Nullable>disable</Nullable>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+		<!-- Override Directory.Build.props defaults that only apply to the shipped libraries -->
+		<SignAssembly>false</SignAssembly>
+		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+		<GenerateDocumentationFile>false</GenerateDocumentationFile>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.6.4" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.6.4" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\LoDaTek.AzureDevOps.Client\LoDaTek.AzureDevOps.Client.csproj" />
+		<ProjectReference Include="..\LoDaTek.AzureDevOps.Services.Client\LoDaTek.AzureDevOps.Services.Client.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/LoDaTek.AzureDevOps.Tests/LoDaTek.AzureDevOps.Tests.csproj
+++ b/LoDaTek.AzureDevOps.Tests/LoDaTek.AzureDevOps.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>disable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>

--- a/LoDaTek.AzureDevOps.Tests/ServiceCollectionExtensionsTests.cs
+++ b/LoDaTek.AzureDevOps.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Net.Http;
+using LoDaTek.AzureDevOps.Services.Client.Bases;
+using LoDaTek.AzureDevOps.Services.Client.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LoDaTek.AzureDevOps.Tests;
+
+/// <summary>
+/// Verifies the DI registration helper wires up the named client used by the REST clients.
+/// </summary>
+[TestClass]
+public class ServiceCollectionExtensionsTests
+{
+    [TestMethod]
+    public void AddAzureDevOpsHttpClient_RegistersNamedClientWithConfiguredTimeout()
+    {
+        var provider = new ServiceCollection()
+            .AddAzureDevOpsHttpClient()
+            .BuildServiceProvider();
+
+        var factory = provider.GetService<IHttpClientFactory>();
+        Assert.IsNotNull(factory, "IHttpClientFactory should be registered.");
+
+        var client = factory.CreateClient(DevOpsConnectionBase.HttpClientName);
+        Assert.AreEqual(TimeSpan.FromSeconds(30), client.Timeout);
+    }
+
+    [TestMethod]
+    public void AddAzureDevOpsHttpClient_ReturnsSameCollectionForChaining()
+    {
+        var services = new ServiceCollection();
+
+        var result = services.AddAzureDevOpsHttpClient();
+
+        Assert.AreSame(services, result);
+    }
+}

--- a/LoDaTek.AzureDevOps.Tests/WiqlBuilderTests.cs
+++ b/LoDaTek.AzureDevOps.Tests/WiqlBuilderTests.cs
@@ -1,0 +1,61 @@
+using System;
+using LoDaTek.AzureDevOps.Client.Builders;
+using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LoDaTek.AzureDevOps.Tests;
+
+/// <summary>
+/// Verifies the WIQL string generation for the documented parameter combinations.
+/// </summary>
+[TestClass]
+public class WiqlBuilderTests
+{
+    [TestMethod]
+    public void BuildString_AllTypes_ExcludesClosedByDefault()
+    {
+        var wiql = WiqlBuilder.BuildString(null, "MyProject", includeClosed: false, changedSince: null);
+
+        StringAssert.Contains(wiql, "Where [System.WorkItemType] <> ''");
+        StringAssert.Contains(wiql, "And [System.TeamProject] = 'MyProject'");
+        StringAssert.Contains(wiql, "AND NOT [System.State] IN ('Completed', 'Closed')");
+        StringAssert.EndsWith(wiql, "Order By [Id] Asc");
+    }
+
+    [TestMethod]
+    public void BuildString_IncludeClosed_OmitsStateFilter()
+    {
+        var wiql = WiqlBuilder.BuildString(null, "MyProject", includeClosed: true, changedSince: null);
+
+        Assert.IsFalse(wiql.Contains("AND NOT [System.State]"), "Closed filter should be omitted when includeClosed is true.");
+    }
+
+    [TestMethod]
+    public void BuildString_WithWorkItemType_FiltersByTypeName()
+    {
+        var type = new WorkItemType { Name = "Bug" };
+
+        var wiql = WiqlBuilder.BuildString(type, "MyProject", includeClosed: true, changedSince: null);
+
+        StringAssert.Contains(wiql, "Where [System.WorkItemType] IN ('Bug')");
+    }
+
+    [TestMethod]
+    public void BuildString_WithChangedSince_AddsSortableDateFilter()
+    {
+        var since = new DateTime(2026, 6, 1, 13, 30, 0, DateTimeKind.Utc);
+
+        var wiql = WiqlBuilder.BuildString(null, "MyProject", includeClosed: true, changedSince: since);
+
+        StringAssert.Contains(wiql, "AND [System.ChangedDate] > '2026-06-01T13:30:00'");
+    }
+
+    [TestMethod]
+    public void BuildQuery_WrapsBuildStringResult()
+    {
+        var query = WiqlBuilder.BuildQuery("MyProject", includeClosed: true, changedSince: null);
+        var expected = WiqlBuilder.BuildString(null, "MyProject", includeClosed: true, changedSince: null);
+
+        Assert.AreEqual(expected, query.Query);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -44,3 +44,23 @@ Works with:
 
         Console.WriteLine($"Cloud Feeds: {feedCount}");
     }
+
+# Using IHttpClientFactory (optional)
+
+By default each connection manages its own `HttpClient`. In a DI app you can instead
+have the REST clients resolve a pooled `HttpClient` from `IHttpClientFactory`.
+
+Register the named client (matches the built-in config — redirects disabled, 30s timeout):
+
+    using LoDaTek.AzureDevOps.Services.Client.Extensions;
+
+    services.AddAzureDevOpsHttpClient();
+
+Then assign the factory to the connection. When `HttpClientFactory` is set, clients are
+resolved from the factory; when it is `null` the built-in client is used, so existing
+code keeps working unchanged.
+
+    var connection = new AzureDevOpsCloudConnection(orgName, pat)
+    {
+        HttpClientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>()
+    };

--- a/SampleWPF/SampleWPF.csproj
+++ b/SampleWPF/SampleWPF.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net9.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UseWPF>true</UseWPF>

--- a/SampleWPF/SampleWPF.csproj
+++ b/SampleWPF/SampleWPF.csproj
@@ -12,7 +12,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="DSoft.System.Mvvm" Version="3.5.2604.111" />
+	  <PackageReference Include="DSoft.System.Mvvm" Version="3.6.2606.131" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/TestApp/TestApp.csproj
+++ b/TestApp/TestApp.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<SignAssembly>false</SignAssembly>
 		<GenerateDocumentationFile>false</GenerateDocumentationFile>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>


### PR DESCRIPTION
## Summary
- Fix `HttpClient` lifetime and connection handling in the Services.Client HTTP base
- Add optional `IHttpClientFactory` support to connections, with `ServiceCollectionExtensions` for DI registration
- Document the optional `IHttpClientFactory` usage in the README
- Update packages and dependencies
- Resolve all build warnings (48 → 0)
- Add a unit + integration test project (`LoDaTek.AzureDevOps.Tests`, MSTest)
- Drop the .NET 9.0 target (libraries now `netstandard2.0;net10.0`)

## Changes
- `DevOpsHttpClientBase` reworked to reuse `HttpClient` instances instead of creating a fresh one per request
- `DevOpsConnectionBase` gains optional `IHttpClientFactory` plumbing; subclasses/consumers can supply a factory
- New `ServiceCollectionExtensions` for registering connections via DI
- `FeedManagmentHttpClient`, `PackageManagementHttpClient`, `SecureFilesHttpClient` updated to the new client model
- README + CLAUDE.md documentation updates

## Target frameworks
- Both libraries now multi-target `netstandard2.0;net10.0` (net9.0 removed)
- Test and sample projects (`LoDaTek.AzureDevOps.Tests`, `TestApp`, `SampleWPF`) retargeted from net9.0 to net10.0

## Build warning cleanup (48 → 0)
| Warning | Fix |
|---|---|
| NU1902/1903/1904 — vulnerable transitive packages from the Azure DevOps SDKs | Pin patched versions: `System.Drawing.Common` 6.0.0, `System.Formats.Asn1` 9.0.17, `System.Security.Cryptography.Xml` 9.0.17 |
| CS0169 — unused fields | Remove `_galleryClient` and `_restApiConnection` |
| CS0168 — unused catch variables | Drop the unused `e` / `ex` names |
| CS0612 — obsolete `GetFieldsAsync` | `#pragma` suppress the single call to preserve the public `List<WorkItemField>` return type |

Notes:
- `Cryptography.Xml` needed ≥ 9.0.15 (8.0.2 and 9.0.9 were themselves vulnerable); used 9.0.17
- `Asn1` bumped to 9.0.17 to avoid an NU1605 downgrade against `Microsoft.Bcl.Cryptography`

## Tests
New MSTest project `LoDaTek.AzureDevOps.Tests` (net10.0), referencing both libraries. Overrides the strong-name signing / packaging defaults from `Directory.Build.props` (those apply to the shipped libraries only).

**Unit tests (14, always run):**
- Connection URL building for cloud, legacy and server host shapes
- `WiqlBuilder` query/string generation across parameter combinations
- `ServiceCollectionExtensions` DI registration of the named `HttpClient`
- Offline `TryConnect` / Basic-auth header behaviour via a stub `IHttpClientFactory` — enabled by the new factory support in this PR, so HTTP logic is covered without a live server

**Integration tests (7, `[TestCategory("Integration")]`):** read-only calls against a live Azure DevOps org, gated on environment variables.
- Required: `AZDO_ORG`, `AZDO_PAT`. Optional: `AZDO_PROJECT`, `AZDO_FEED`
- When unset they `Assert.Inconclusive` (skip, not fail), so default runs stay green without credentials
- Cover: `GetFeedsAsync`, `GetPackagesAsync`, `GetNugetBasePathAsync`; provider `GetProjectsAsync` / `GetProjectAsync` / `FetchAvailableFeedsAsync`; secure files for a project

```
dotnet test --filter TestCategory!=Integration   # unit only
dotnet test --filter TestCategory=Integration     # integration only (needs env vars)
```

## Test plan
- `dotnet build` of both libraries across `netstandard2.0;net10.0` — both build clean with 0 warnings / 0 errors
- `TestApp` and `SampleWPF` build clean on net10.0
- `dotnet test` — 14 unit tests pass; 7 integration tests skip (inconclusive) without credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)
